### PR TITLE
Fix for not correctly refreshing digits after switching to or from night time dimming mode

### DIFF
--- a/EleksTubeHAX_pio/src/main.cpp
+++ b/EleksTubeHAX_pio/src/main.cpp
@@ -887,12 +887,14 @@ void checkDimmingNeeded()
     { // check if it is in the defined night time
       Serial.println("Set to night time mode (dimmed)!");
       tfts.dimming = TFT_DIMMED_INTENSITY;
+      tfts.InvalidateImageInBuffer();
       backlights.setDimming(true);
     }
     else
     {
       Serial.println("Set to day time mode (normal brightness)!");
       tfts.dimming = 255; // 0..255
+      tfts.InvalidateImageInBuffer();
       backlights.setDimming(false);
     }
     updateClockDisplay(TFTs::force); // redraw all the clock digits -> software dimming will be done here


### PR DESCRIPTION
checkDimmingNeeded() needs to invalidate the actual image buffer, because the "cache" still holds the old image.

Added tfts.InvalidateImageInBuffer() for both directions (from and to night time change).