### PR TITLE
Make rainbow pattern go dark during dimming and backlight dimmed intensity is 0

### DIFF
--- a/EleksTubeHAX_pio/src/Backlights.cpp
+++ b/EleksTubeHAX_pio/src/Backlights.cpp
@@ -251,7 +251,11 @@ void Backlights::rainbowPattern()
   }
   if (dimming)
   {
-    setBrightness(0xFF >> max_intensity - (uint8_t)BACKLIGHT_DIMMED_INTENSITY - 1);
+    #if BACKLIGHT_DIMMED_INTENSITY > 0
+      setBrightness(0xFF >> max_intensity - (uint8_t)BACKLIGHT_DIMMED_INTENSITY - 1);
+    #else  //turn off backlight if intensity is 0
+      setBrightness(0);
+    #endif
   }
   else
   {


### PR DESCRIPTION
small PR that resolves #113 
uses preprocessor directives since BACKLIGHT_DIMMED_INTENSITY itself is a macro and doesn't change during runtime