### PR TITLE
Fix linux build unneeded dependencies

### DIFF
--- a/EleksTubeHAX_pio/platformio.ini
+++ b/EleksTubeHAX_pio/platformio.ini
@@ -10,7 +10,17 @@
 
 ; common settings for all environments
 [env]
+
+; ───────────────────────────────────────────────────────────────
+; === Platform Dependencies ===
+; No specific version is defined to always use the latest 
+; compatible version available. If issues arise due to updates, 
+; a specific version can be set like this:
+; platform = espressif32@^6.10.0
+; However, this is not required by default.
+; ───────────────────────────────────────────────────────────────
 platform = espressif32
+
 framework = arduino
 upload_speed = 921600
 monitor_speed = 115200
@@ -35,15 +45,15 @@ lib_deps =
 	makuna/RTC
 	
 	; ───────────────────────────────────────────────────────────────
-	; === Tested and working with following versions. If you have issues, revert to libraries listed below. ===
-	; adafruit/Adafruit NeoPixel@^1.12.5
-	; paulstoffregen/Time@^1.6.1
-	; paulstoffregen/DS1307RTC@^0.0.0-alpha+sha.c2590c0033
-	; bodmer/TFT_eSPI@^2.5.43
-	; knolleary/PubSubClient@^2.8.0
-	; bblanchon/ArduinoJson@^7.3.1
-	; sparkfun/SparkFun APDS9960 RGB and Gesture Sensor@^1.4.3
-	; makuna/RTC@^2.5.0
+	; === Tested and working with following versions. If you have issues, revert to library versions listed below. ===
+	; adafruit/Adafruit NeoPixel@1.12.5
+	; paulstoffregen/Time@1.6.1
+	; paulstoffregen/DS1307RTC@0.0.0-alpha+sha.c2590c0033
+	; bodmer/TFT_eSPI@2.5.43
+	; knolleary/PubSubClient@2.8.0
+	; bblanchon/ArduinoJson@7.3.1
+	; sparkfun/SparkFun APDS9960 RGB and Gesture Sensor@1.4.3
+	; makuna/RTC@2.5.0
 	; ───────────────────────────────────────────────────────────────
 
 	; ───────────────────────────────────────────────────────────────

--- a/EleksTubeHAX_pio/platformio.ini
+++ b/EleksTubeHAX_pio/platformio.ini
@@ -14,6 +14,16 @@ platform = espressif32
 framework = arduino
 upload_speed = 921600
 monitor_speed = 115200
+
+; ───────────────────────────────────────────────────────────────
+; === Library Dependencies ===
+; No specific versions are defined to always use the latest 
+; compatible versions available. If issues arise due to updates, 
+; a specific version can be set like this:
+; lib_deps =
+;     bblanchon/ArduinoJson@^7.0.3
+; However, this is not required by default.
+; ───────────────────────────────────────────────────────────────
 lib_deps = 
 	adafruit/Adafruit NeoPixel
 	paulstoffregen/Time
@@ -21,29 +31,32 @@ lib_deps =
 	bodmer/TFT_eSPI
 	knolleary/PubSubClient
 	bblanchon/ArduinoJson
-	Wire
-	SPI
-	FS
-	SPIFFS
 	sparkfun/SparkFun APDS9960 RGB and Gesture Sensor
 	makuna/RTC
+	
+	; ───────────────────────────────────────────────────────────────
+	; === Tested and working with following versions. If you have issues, revert to libraries listed below. ===
+	; adafruit/Adafruit NeoPixel@^1.12.5
+	; paulstoffregen/Time@^1.6.1
+	; paulstoffregen/DS1307RTC@^0.0.0-alpha+sha.c2590c0033
+	; bodmer/TFT_eSPI@^2.5.43
+	; knolleary/PubSubClient@^2.8.0
+	; bblanchon/ArduinoJson@^7.3.1
+	; sparkfun/SparkFun APDS9960 RGB and Gesture Sensor@^1.4.3
+	; makuna/RTC@^2.5.0
+	; ───────────────────────────────────────────────────────────────
 
-	; These libraries and source files are causing boot-loop-crash. Do not use. TO-DO: replace with different libraries and source files.
+	; ───────────────────────────────────────────────────────────────
+	; === These libraries and source files are causing boot-loop-crashes sometimes. Do not use! ===
+	; TO-DO: replace with different libraries and source files.
 	; milesburton/DallasTemperature
 	; OneWire
+	; ───────────────────────────────────────────────────────────────
 
-	; === Tested and working with following versions. If you have issues, revert to libraries listed below. ===
-	; adafruit/Adafruit NeoPixel@^1.12.0
-	; paulstoffregen/Time@^1.6.1
-	; paulstoffregen/DS1307RTC
-	; bodmer/TFT_eSPI@^2.5.43
-	; knolleary/PubSubClient@^2.8
-	; bblanchon/ArduinoJson@^7.0.3
-	; sparkfun/SparkFun APDS9960 RGB and Gesture Sensor@^1.4.3
-	; makuna/RTC@^2.4.2
 build_flags =
 	-DCORE_DEBUG_LEVEL=5	; Set to 0 for no debug; saves flash memory; Set to 5 for full debug
 	; -D CREATE_FIRMWAREFILE	; "activate" the extra_script script_build_fs_and_merge.py
+board_build.filesystem = spiffs
 
 extra_scripts =
 	; copy configuration files into TFT_eSPI library folder


### PR DESCRIPTION
Update platformio.ini - removed libs which are already included in the arduino framework for esp32 - reformated libs section - added newer versions number for libs (in the comments) - added spiffs as default filesystem target - improve comments for platform dependencies and library versions