### PR TITLE
Fix some rtc stuff

### DIFF
--- a/EleksTubeHAX_pio/lib/modified_RTC_RX8025T/RTC_RX8025T.cpp
+++ b/EleksTubeHAX_pio/lib/modified_RTC_RX8025T/RTC_RX8025T.cpp
@@ -1,0 +1,347 @@
+/*-----------------------------------------------------------------------*
+ * RTC_RX8025T.cpp - Arduino library for the Seiko Epson RX8025T         *
+ * Real Time Clock. Modified version of the original library.            *
+ *                                                                       *
+ * This library has been modified for custom usage in the EleksTubeHAX   *
+ * project.                                                              *
+ * Original library from Marcin Saj                                      *
+ * Original library based on the Paul Stoffregen DS3232RTC.              *
+ *                                                                       *
+ * The MIT License                                                       *
+ * Marcin Saj 25 OCT 2022                                                *
+ * Modified by Clemens Sutor (Martinius79) on 07-04-2025                 *
+ * https://github.com/marcinsaj/RTC_RX8025T                              *
+ *-----------------------------------------------------------------------*/
+
+#include <RTC_RX8025T.h>
+#include <Wire.h>
+
+RX8025T::RX8025T()
+{
+}
+/*----------------------------------------------------------------------*
+ * I2C start, RTC initialization, cleaning of registers and flags.      *
+ * If the VLF flag is "1" there was data loss or                        *
+ * supply voltage drop or powering up from 0V.                          *
+ * If VDET flag is "1" temperature compensation is not working.         *
+ * Default settings.                                                    *
+ *----------------------------------------------------------------------*/
+void RX8025T::init(void)
+{
+  uint8_t statusReg, mask;
+
+  Wire1.begin();
+
+  statusReg = readRTC(RX8025T_RTC_STATUS);
+  mask = _BV(VLF) | _BV(VDET);
+
+  if (statusReg & mask)
+  {
+    writeRTC(RX8025T_RTC_CONTROL, _BV(RESET)); // Reset module
+  }
+
+  // Clear control registers
+  writeRTC(RX8025T_RTC_EXT, 0x00);
+  writeRTC(RX8025T_RTC_STATUS, 0x00);
+  // Dafault value of temperature compensation interval is 2 seconds
+  writeRTC(RX8025T_RTC_CONTROL, (0x00 | INT_2_SEC));
+}
+
+void RX8025T::init(uint32_t rtcSDA, uint32_t rtcSCL)
+{
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("DEBUG_OUTPUT_RTC: Entering RX8025T_init(uint32_t, uint32_t)");
+  Serial.print("DEBUG_OUTPUT_RTC: Initializing Wire1 with SDA = ");
+  Serial.print(rtcSDA);
+  Serial.print(", SCL = ");
+  Serial.println(rtcSCL);
+#endif
+  Wire1.begin(rtcSDA, rtcSCL);
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("DEBUG_OUTPUT_RTC: Wire1.begin completed");
+#endif
+
+  uint8_t statusReg, mask;
+  statusReg = readRTC(RX8025T_RTC_STATUS);
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.print("DEBUG_OUTPUT_RTC: Read status register: 0x");
+  Serial.println(statusReg, HEX);
+#endif
+  mask = _BV(VLF) | _BV(VDET);
+
+  if (statusReg & mask)
+  {
+#ifdef DEBUG_OUTPUT_RTC
+    Serial.println("DEBUG_OUTPUT_RTC: Status flags indicate data loss or temp compensation error, resetting RTC module.");
+#endif
+    writeRTC(RX8025T_RTC_CONTROL, _BV(RESET)); // Reset module
+  }
+
+  // Clear control registers
+  writeRTC(RX8025T_RTC_EXT, 0x00);
+  writeRTC(RX8025T_RTC_STATUS, 0x00);
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("DEBUG_OUTPUT_RTC: Control registers cleared");
+#endif
+  // Dafault value of temperature compensation interval is 2 seconds
+  writeRTC(RX8025T_RTC_CONTROL, (0x00 | INT_2_SEC));
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("DEBUG_OUTPUT_RTC: Temperature compensation interval set to 2 seconds; RTC init complete.");
+#endif
+}
+
+/*----------------------------------------------------------------------*
+ * Reads the current time from the RTC and returns it as a time_t       *
+ * value. Returns a zero value if an I2C error occurred (e.g. RTC       *
+ * not present).                                                        *
+ *----------------------------------------------------------------------*/
+time_t RX8025T::get()
+{
+  tmElements_t tm;
+
+  if (read(tm))
+    return 0;
+  return (makeTime(tm));
+}
+
+/*----------------------------------------------------------------------*
+ * Sets the RTC to the given time_t value and clears the                *
+ * oscillator stop flag (OSF) in the Control/Status register.           *
+ * Returns the I2C status (zero if successful).                         *
+ *----------------------------------------------------------------------*/
+uint8_t RX8025T::set(time_t t)
+{
+  tmElements_t tm;
+
+  breakTime(t, tm);
+  return (write(tm));
+}
+
+/*----------------------------------------------------------------------*
+ * Reads the current time from the RTC and returns it in a tmElements_t *
+ * structure. Returns the I2C status (zero if successful).              *
+ *----------------------------------------------------------------------*/
+uint8_t RX8025T::read(tmElements_t &tm)
+{
+  Wire1.beginTransmission(RX8025T_ADDR);
+  Wire1.write((uint8_t)RX8025T_SECONDS);
+  if (uint8_t e = Wire1.endTransmission())
+    return e;
+  // request 7 bytes (secs, min, hr, dow, date, mth, yr)
+  Wire1.requestFrom(RX8025T_ADDR, tmNbrFields);
+  tm.Second = bcd2dec(Wire1.read());
+  tm.Minute = bcd2dec(Wire1.read());
+  tm.Hour = bcd2dec(Wire1.read());
+  tm.Wday = bin2wday(Wire1.read());
+  tm.Day = bcd2dec(Wire1.read());
+  tm.Month = bcd2dec(Wire1.read());
+  tm.Year = y2kYearToTm(bcd2dec(Wire1.read()));
+  return 0;
+}
+
+/*----------------------------------------------------------------------*
+ * Sets the RTC's time from a tmElements_t structure and clears the     *
+ * oscillator stop flag (OSF) in the Control/Status register.           *
+ * Returns the I2C status (zero if successful).                         *
+ *----------------------------------------------------------------------*/
+uint8_t RX8025T::write(tmElements_t &tm)
+{
+  Wire1.beginTransmission(RX8025T_ADDR);
+  Wire1.write((uint8_t)RX8025T_SECONDS);
+  Wire1.write(dec2bcd(tm.Second));
+  Wire1.write(dec2bcd(tm.Minute));
+  Wire1.write(dec2bcd(tm.Hour));
+  Wire1.write(wday2bin(tm.Wday));
+  Wire1.write(dec2bcd(tm.Day));
+  Wire1.write(dec2bcd(tm.Month));
+  Wire1.write(dec2bcd(tmYearToY2k(tm.Year)));
+  uint8_t ret = Wire1.endTransmission();
+  return ret;
+}
+
+/*----------------------------------------------------------------------*
+ * Write multiple bytes to RTC RAM.                                     *
+ * Valid address range is 0x00 - 0xFF, no checking.                     *
+ * Number of bytes (nBytes) must be between 1 and 31 (Wire library      *
+ * limitation).                                                         *
+ * Returns the I2C status (zero if successful).                         *
+ *----------------------------------------------------------------------*/
+uint8_t RX8025T::writeRTC(uint8_t addr, uint8_t *values, uint8_t nBytes)
+{
+  Wire1.beginTransmission(RX8025T_ADDR);
+  Wire1.write(addr);
+  for (uint8_t i = 0; i < nBytes; i++)
+    Wire1.write(values[i]);
+  return Wire1.endTransmission();
+}
+
+/*----------------------------------------------------------------------*
+ * Write a single uint8_t to RTC RAM.                                   *
+ * Valid address range is 0x00 - 0xFF, no checking.                     *
+ * Returns the I2C status (zero if successful).                         *
+ *----------------------------------------------------------------------*/
+uint8_t RX8025T::writeRTC(uint8_t addr, uint8_t value)
+{
+  return (writeRTC(addr, &value, 1));
+}
+
+/*----------------------------------------------------------------------*
+ * Read multiple bytes from RTC RAM.                                    *
+ * Valid address range is 0x00 - 0xFF, no checking.                     *
+ * Number of bytes (nBytes) must be between 1 and 32 (Wire library      *
+ * limitation).                                                         *
+ * Returns the I2C status (zero if successful).                         *
+ *----------------------------------------------------------------------*/
+uint8_t RX8025T::readRTC(uint8_t addr, uint8_t *values, uint8_t nBytes)
+{
+  Wire1.beginTransmission(RX8025T_ADDR);
+  Wire1.write(addr);
+  if (uint8_t e = Wire1.endTransmission())
+    return e;
+  Wire1.requestFrom((uint8_t)RX8025T_ADDR, nBytes);
+  for (uint8_t i = 0; i < nBytes; i++)
+    values[i] = Wire1.read();
+  return 0;
+}
+
+/*----------------------------------------------------------------------*
+ * Read a single uint8_t from RTC RAM.                                  *
+ * Valid address range is 0x00 - 0xFF, no checking.                     *
+ *----------------------------------------------------------------------*/
+uint8_t RX8025T::readRTC(uint8_t addr)
+{
+  uint8_t b;
+
+  readRTC(addr, &b, 1);
+  return b;
+}
+
+/*----------------------------------------------------------------------*
+ * Time update interrupt initialization setup.                          *
+ * Function generates - INT output - interrupt events at one-second     *
+ * or one-minute intervals.                                             *
+ * USEL bit "0"-every second, "1"-every minute.                         *
+ *----------------------------------------------------------------------*/
+void RX8025T::initTUI(uint8_t option)
+{
+  uint8_t extReg, mask;
+
+  extReg = readRTC(RX8025T_RTC_EXT);
+  mask = _BV(USEL);
+
+  extReg = (extReg & ~mask) | (mask & option);
+  writeRTC(RX8025T_RTC_EXT, extReg);
+}
+
+/*----------------------------------------------------------------------*
+ * Time update interrupt event ON/OFF.                                  *
+ * UIE bit "1"-ON, "0"-OFF                                              *
+ *----------------------------------------------------------------------*/
+void RX8025T::statusTUI(uint8_t status)
+{
+  uint8_t controlReg, mask;
+
+  controlReg = readRTC(RX8025T_RTC_CONTROL);
+  mask = _BV(UIE);
+
+  controlReg = (controlReg & ~mask) | (mask & status);
+  writeRTC(RX8025T_RTC_CONTROL, controlReg);
+}
+
+/*----------------------------------------------------------------------*
+ * Time update interrupt UF status flag.                                *
+ * If for some reason the hardware interrupt has not been               *
+ * registered/handled, it is always possible to check the UF flag.      *
+ * If UF"1" the interrupt has occurred.                                 *
+ *----------------------------------------------------------------------*/
+bool RX8025T::checkTUI(void)
+{
+  uint8_t statusReg, mask;
+
+  statusReg = readRTC(RX8025T_RTC_STATUS);
+  mask = _BV(UF);
+
+  if (statusReg & mask)
+  {
+    // Clear UF flag
+    statusReg = statusReg & ~mask;
+    writeRTC(RX8025T_RTC_STATUS, statusReg);
+    return 1;
+  }
+  else
+    return 0;
+}
+
+/*----------------------------------------------------------------------*
+ * Temperature compensation interval settings.                          *
+ * CSEL0, CSEL1 - 0.5s, 2s-default, 10s, 30s                            *
+ *----------------------------------------------------------------------*/
+void RX8025T::tempCompensation(uint8_t option)
+{
+  uint8_t controlReg, mask;
+
+  controlReg = readRTC(RX8025T_RTC_CONTROL);
+  mask = _BV(CSEL0) | _BV(CSEL1);
+
+  controlReg = (controlReg & ~mask) | (mask & option);
+  writeRTC(RX8025T_RTC_CONTROL, controlReg);
+}
+
+/*----------------------------------------------------------------------*
+ * FOUT frequency output settings                                       *
+ * If FOE input = "H" (high level) then FOUT is active.                 *
+ * FSEL0, FSEL1 - 32768Hz, 1024H, 1Hz                                   *
+ *----------------------------------------------------------------------*/
+void RX8025T::initFOUT(uint8_t option)
+{
+
+  uint8_t extReg, mask;
+
+  extReg = readRTC(RX8025T_RTC_EXT);
+  mask = _BV(FSEL0) | _BV(FSEL1);
+
+  extReg = (extReg & ~mask) | (mask & option);
+  writeRTC(RX8025T_RTC_EXT, extReg);
+}
+
+/*----------------------------------------------------------------------*
+ * Decimal-to-Dedicated format conversion - RTC datasheet page 12       *
+ * Sunday 0x01,...Wednesday 0x08,...Saturday 0x40                       *
+ *----------------------------------------------------------------------*/
+uint8_t RX8025T::wday2bin(uint8_t wday)
+{
+  return _BV(wday - 1);
+}
+
+/*----------------------------------------------------------------------*
+ * Dedicated-to-Decimal format conversion - RTC datasheet page 12       *
+ * Sunday 1, Monday 2, Tuesday 3...                                     *
+ *----------------------------------------------------------------------*/
+uint8_t __attribute__((noinline)) RX8025T::bin2wday(uint8_t wday)
+{
+  for (int i = 0; i < 7; i++)
+  {
+    if ((wday >> i) == 1)
+      wday = i + 1;
+  }
+
+  return wday;
+}
+
+/*----------------------------------------------------------------------*
+ * Decimal-to-BCD conversion                                            *
+ *----------------------------------------------------------------------*/
+uint8_t RX8025T::dec2bcd(uint8_t n)
+{
+  return n + 6 * (n / 10);
+}
+
+/*----------------------------------------------------------------------*
+ * BCD-to-Decimal conversion                                            *
+ *----------------------------------------------------------------------*/
+uint8_t __attribute__((noinline)) RX8025T::bcd2dec(uint8_t n)
+{
+  return n - 6 * (n >> 4);
+}
+
+RX8025T RTC_RX8025T = RX8025T();

--- a/EleksTubeHAX_pio/lib/modified_RTC_RX8025T/RTC_RX8025T.h
+++ b/EleksTubeHAX_pio/lib/modified_RTC_RX8025T/RTC_RX8025T.h
@@ -1,0 +1,124 @@
+/*-----------------------------------------------------------------------*
+ * MODIFIED RTC_RX8025T.h - Arduino library for the Seiko Epson RX8025T  *
+ * Real Time Clock. Modified version of the original library.            *
+ *                                                                       *
+ * This library has been modified for custom usage in the EleksTubeHAX   *
+ * project.                                                              *
+ * Original library from Marcin Saj                                      *
+ * Original library based on the Paul Stoffregen DS3232RTC.              *
+ *                                                                       *
+ * The MIT License                                                       *
+ * Marcin Saj 25 OCT 2022                                                *
+ * Modified by Clemens Sutor (Martinius79) on 07-04-2025                 *
+ * https://github.com/marcinsaj/RTC_RX8025T                              *
+ *-----------------------------------------------------------------------*/
+
+#ifndef RTC_RX8025T_h
+#define RTC_RX8025T_h
+
+#include <TimeLib.h>
+#include "../../src/_USER_DEFINES.h" // User defines (located in the src folder)
+
+#if defined(ARDUINO) && ARDUINO >= 100
+#include <Arduino.h>
+#else
+#include <WProgram.h>
+#endif
+
+// #define _BV2(bit) (1 << (bit))
+
+// RX8025T I2C Address
+#define RX8025T_ADDR 0x32
+
+// RX8025T Register Addresses
+#define RX8025T_SECONDS 0x00
+#define RX8025T_MINUTES 0x01
+#define RX8025T_HOURS 0x02
+#define RX8025T_DAY 0x03
+#define RX8025T_DATE 0x04
+#define RX8025T_MONTH 0x05
+#define RX8025T_YEAR 0x06
+#define RX8025T_RAM 0x07
+#define RX8025T_ALARM_MINUTES 0x08
+#define RX8025T_ALARM_HOURS 0x09
+#define RX8025T_ALARM_DAYDATE 0x0A
+#define RX8025T_TIMER_COUNTER_0 0x0B
+#define RX8025T_TIMER_COUNTER_1 0x0C
+#define RX8025T_RTC_EXT 0x0D
+#define RX8025T_RTC_STATUS 0x0E
+#define RX8025T_RTC_CONTROL 0x0F
+
+// Extension register bits
+#define TSEL0 0
+#define TSEL1 1
+#define FSEL0 2
+#define FSEL1 3
+#define TE 4
+#define USEL 5
+#define WADA 6
+
+// Status register bits
+#define VDET 0
+#define VLF 1
+#define AF 3
+#define TF 4
+#define UF 5
+
+// Control register bits
+#define RESET 0
+#define AIE 3
+#define TIE 4
+#define UIE 5
+#define CSEL0 6
+#define CSEL1 7
+
+// Time update interrupt function
+#define INT_SECOND 0x00
+#define INT_MINUTE 0x20
+
+// Time update interrupt
+#define INT_ON 0x20
+#define INT_OFF 0x00
+
+// Temperature compensation interval
+#define INT_0_5_SEC 0x00
+#define INT_2_SEC 0x40
+#define INT_10_SEC 0x80
+#define INT_30_SEC 0xC0
+
+// FOUT frequency
+#define FOUT_32768 0x00 // or 0x0C
+#define FOUT_1024 0x04
+#define FOUT_1 0x08
+
+class RX8025T
+{
+public:
+        RX8025T();
+        void init(void);
+        void init(uint32_t SDA, uint32_t SCL);
+        static time_t get(void); // Must be static to work with setSyncProvider() in the Time library
+        uint8_t set(time_t t);
+        static uint8_t read(tmElements_t &tm);
+        uint8_t write(tmElements_t &tm);
+        uint8_t writeRTC(uint8_t addr, uint8_t *values, uint8_t nBytes);
+        uint8_t writeRTC(uint8_t addr, uint8_t value);
+        uint8_t readRTC(uint8_t addr, uint8_t *values, uint8_t nBytes);
+        uint8_t readRTC(uint8_t addr);
+        void tempCompensation(uint8_t option);
+        void initFOUT(uint8_t option);
+        void initTUI(uint8_t option);
+        void statusTUI(uint8_t status);
+        bool checkTUI(void);
+
+private:
+        uint8_t currentStateUIEbit;
+        uint8_t wday2bin(uint8_t wday);
+        static uint8_t bin2wday(uint8_t wday);
+        uint8_t dec2bcd(uint8_t n);
+        static uint8_t bcd2dec(uint8_t n);
+};
+
+extern RX8025T RTC_RX8025T;
+
+#endif

--- a/EleksTubeHAX_pio/platformio.ini
+++ b/EleksTubeHAX_pio/platformio.ini
@@ -36,24 +36,24 @@ monitor_speed = 115200
 ; ───────────────────────────────────────────────────────────────
 lib_deps = 
 	adafruit/Adafruit NeoPixel
-	paulstoffregen/Time
-	paulstoffregen/DS1307RTC
+	paulstoffregen/Time	
 	bodmer/TFT_eSPI
 	knolleary/PubSubClient
 	bblanchon/ArduinoJson
 	sparkfun/SparkFun APDS9960 RGB and Gesture Sensor
 	makuna/RTC
-	
+	adafruit/RTClib
+
 	; ───────────────────────────────────────────────────────────────
 	; === Tested and working with following versions. If you have issues, revert to library versions listed below. ===
 	; adafruit/Adafruit NeoPixel@1.12.5
-	; paulstoffregen/Time@1.6.1
-	; paulstoffregen/DS1307RTC@0.0.0-alpha+sha.c2590c0033
+	; paulstoffregen/Time@1.6.1	
 	; bodmer/TFT_eSPI@2.5.43
 	; knolleary/PubSubClient@2.8.0
 	; bblanchon/ArduinoJson@7.3.1
 	; sparkfun/SparkFun APDS9960 RGB and Gesture Sensor@1.4.3
 	; makuna/RTC@2.5.0
+	; adafruit/RTClib@^2.1.4
 	; ───────────────────────────────────────────────────────────────
 
 

--- a/EleksTubeHAX_pio/src/Clock.cpp
+++ b/EleksTubeHAX_pio/src/Clock.cpp
@@ -2,7 +2,6 @@
 #include "WiFi_WPS.h"
 
 #if defined(HARDWARE_SI_HAI_CLOCK) || defined(HARDWARE_IPSTUBE_CLOCK) // for Clocks with DS1302 chip (SI HAI or IPSTUBE)
-// If it is a SI HAI Clock, use differnt RTC chip drivers
 #include <ThreeWire.h>
 #include <RtcDS1302.h>
 ThreeWire myWire(DS1302_IO, DS1302_SCLK, DS1302_CE); // IO, SCLK, CE
@@ -10,7 +9,7 @@ RtcDS1302<ThreeWire> RTC(myWire);
 void RtcBegin()
 {
 #ifdef DEBUG_OUTPUT_RTC
-  Serial.println("DEBUG_OUTPUT_RTC: Tryng to call RTC.Begin()");
+  Serial.println("DEBUG_OUTPUT_RTC: Tryng to call DS1302 RTC.Begin()");
 #endif
   RTC.Begin();
   if (!RTC.IsDateTimeValid())
@@ -19,32 +18,34 @@ void RtcBegin()
     //    1) the entire RTC was just set to the default date (01/01/2000 00:00:00)
     //    2) first time you ran and the device wasn't running yet
     //    3) the battery on the device is low or even missing
-    Serial.println("RTC lost confidence in the DateTime!");
+    Serial.println("DS1302 RTC lost confidence in the DateTime!");
   }
   if (RTC.GetIsWriteProtected())
   {
-    Serial.println("RTC was write protected, enabling writing now");
+    Serial.println("DS1302 RTC was write protected, enabling writing now");
     RTC.SetIsWriteProtected(false);
   }
 
   if (!RTC.GetIsRunning())
   {
-    Serial.println("RTC was not actively running, starting now");
+    Serial.println("DS1302 RTC was not actively running, starting now");
     RTC.SetIsRunning(true);
   }
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("DEBUG_OUTPUT_RTC: RTC DS1302 initialized!");
+#endif
 }
 
 uint32_t RtcGet()
 {
-#ifdef DEBUG_OUTPUT_RTC
-  Serial.println("DEBUG_OUTPUT_RTC: RtcGet() for DS1302 RTC entered.");
-  Serial.println("DEBUG_OUTPUT_RTC: Calling RTC.GetDateTime()...");
+#ifdef DEBUG_OUTPUT_RTC  
+  Serial.println("DEBUG_OUTPUT_RTC: Calling DS1302 RTC.GetDateTime()...");
 #endif
   RtcDateTime temptime;
   temptime = RTC.GetDateTime();
   uint32_t returnvalue = temptime.Unix32Time();
 #ifdef DEBUG_OUTPUT_RTC
-  Serial.print("DEBUG_OUTPUT_RTC: RTC.GetDateTime() returned: ");
+  Serial.print("DEBUG_OUTPUT_RTC: DS1302 RTC.GetDateTime() returned: ");
   Serial.println(returnvalue);
 #endif
   return returnvalue;
@@ -52,8 +53,7 @@ uint32_t RtcGet()
 
 void RtcSet(uint32_t tt)
 {
-#ifdef DEBUG_OUTPUT_RTC
-  Serial.println("DEBUG_OUTPUT_RTC: RtcSet() for DS1302 RTC entered.");
+#ifdef DEBUG_OUTPUT_RTC  
   Serial.print("DEBUG_OUTPUT_RTC: Setting DS1302 RTC to: ");
   Serial.println(tt);
 #endif
@@ -73,7 +73,7 @@ void RtcBegin()
 {
 #ifdef DEBUG_OUTPUT_RTC
   Serial.println("");
-  Serial.println("DEBUG_OUTPUT_RTC: Trying to call RTC.Init()");
+  Serial.println("DEBUG_OUTPUT_RTC: Trying to call RX8025T RTC.Init()");
 #endif
   RTC.init((uint32_t)RTC_SDA_PIN, (uint32_t)RTC_SCL_PIN); // setup second I2C for the RX8025T RTC chip
 #ifdef DEBUG_OUTPUT_RTC
@@ -125,12 +125,12 @@ void RtcBegin()
 {
   if (!RTC.begin())
   {
-    Serial.println("NO supported RTC found!");
+    Serial.println("No supported RTC found!");
   }
   else
   {
 #ifdef DEBUG_OUTPUT_RTC
-    Serial.println("DEBUG_OUTPUT_RTC: RTC found!");
+    Serial.println("DEBUG_OUTPUT_RTC: DS3231/DS1307 RTC found!");
 #endif
   }
 
@@ -139,8 +139,14 @@ void RtcBegin()
   bPowerLost = RTC.lostPower();
   if (bPowerLost)
   {
-    Serial.println("RTC reports power was lost! Setting time to default value.");
+    Serial.println("DS3231/DS1307 RTC reports power was lost! Setting time to default value.");
     RTC.adjust(DateTime(2023, 1, 1, 0, 0, 0)); // set the RTC time to a default value
+  }
+  else
+  {
+#ifdef DEBUG_OUTPUT_RTC
+    Serial.println("DEBUG_OUTPUT_RTC: DS3231/DS1307 RTC power is OK!");
+#endif
   }
 }
 
@@ -149,7 +155,7 @@ uint32_t RtcGet()
   DateTime now = RTC.now(); // convert to unix time
   uint32_t returnvalue = now.unixtime();
 #ifdef DEBUG_OUTPUT_RTC
-  Serial.print("DEBUG_OUTPUT_RTC: DS3231 RTC now.unixtime() = ");
+  Serial.print("DEBUG_OUTPUT_RTC: DS3231/DS1307 RTC now.unixtime() returned: ");
   Serial.println(returnvalue);
 #endif
   return returnvalue;
@@ -158,14 +164,14 @@ uint32_t RtcGet()
 void RtcSet(uint32_t tt)
 {
 #ifdef DEBUG_OUTPUT_RTC
-  Serial.print("DEBUG_OUTPUT_RTC: Attempting to set DS3231 RTC to: ");
+  Serial.print("DEBUG_OUTPUT_RTC: Attempting to set DS3231/DS1307 RTC to: ");
   Serial.println(tt);
 #endif
 
   DateTime timetoset(tt); // convert to unix time
   RTC.adjust(timetoset);  // set the RTC time
 #ifdef DEBUG_OUTPUT
-  Serial.println("DEBUG_OUTPUT_RTC: DS3231 RTC time updated.");
+  Serial.println("DEBUG_OUTPUT_RTC: DS3231/DS1307 RTC time updated.");
 #endif
 }
 #endif // end of RTC chip selection
@@ -178,7 +184,7 @@ void Clock::begin(StoredConfig::Config::Clock *config_)
   {
     // Config is invalid, probably a new device never had its config written.
     // Load some reasonable defaults.
-    Serial.println("Loaded Clock config is invalid, using default.  This is normal on first boot.");
+    Serial.println("Loaded Clock config is invalid, using default config values. This is normal on first boot.");
     setTwelveHour(false);
     setBlankHoursZero(false);
     setTimeZoneOffset(1 * 3600); // CET

--- a/EleksTubeHAX_pio/src/Clock.cpp
+++ b/EleksTubeHAX_pio/src/Clock.cpp
@@ -1,73 +1,174 @@
 #include "Clock.h"
 #include "WiFi_WPS.h"
 
-#if defined(HARDWARE_SI_HAI_CLOCK) || defined(HARDWARE_IPSTUBE_CLOCK) // for Clocks with DS1302 chip #SI HAI or IPSTUBE XXXXXXXXXXXXXXXXXX
+#if defined(HARDWARE_SI_HAI_CLOCK) || defined(HARDWARE_IPSTUBE_CLOCK) // for Clocks with DS1302 chip (SI HAI or IPSTUBE)
 // If it is a SI HAI Clock, use differnt RTC chip drivers
 #include <ThreeWire.h>
 #include <RtcDS1302.h>
 ThreeWire myWire(DS1302_IO, DS1302_SCLK, DS1302_CE); // IO, SCLK, CE
-RtcDS1302<ThreeWire> Rtc(myWire);
+RtcDS1302<ThreeWire> RTC(myWire);
 void RtcBegin()
 {
-  Rtc.Begin();
-  // check if chip is connected and alive
-  /*  TCS default value is 0x00 instead of 0x5C, but RTC seems to be working. Let's skip this check.
-      Serial.print("Checking DS1302 RTC... ");
-      uint8_t TCS = Rtc.GetTrickleChargeSettings();  // 01011100  Initial power-on state
-      Serial.print("TCS = ");
-      Serial.println(TCS);
-      if (TCS != 0x5C) {
-        Serial.println("Error communicating with DS1302 !");
-      }
-  */
-  if (!Rtc.IsDateTimeValid())
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("DEBUG_OUTPUT_RTC: Tryng to call RTC.Begin()");
+#endif
+  RTC.Begin();
+  if (!RTC.IsDateTimeValid())
   {
-    // Common Causes:
-    //    1) first time you ran and the device wasn't running yet
-    //    2) the battery on the device is low or even missing
+    // Common Causes for this to be true:
+    //    1) the entire RTC was just set to the default date (01/01/2000 00:00:00)
+    //    2) first time you ran and the device wasn't running yet
+    //    3) the battery on the device is low or even missing
     Serial.println("RTC lost confidence in the DateTime!");
   }
-  if (Rtc.GetIsWriteProtected())
+  if (RTC.GetIsWriteProtected())
   {
     Serial.println("RTC was write protected, enabling writing now");
-    Rtc.SetIsWriteProtected(false);
+    RTC.SetIsWriteProtected(false);
   }
 
-  if (!Rtc.GetIsRunning())
+  if (!RTC.GetIsRunning())
   {
     Serial.println("RTC was not actively running, starting now");
-    Rtc.SetIsRunning(true);
+    RTC.SetIsRunning(true);
   }
 }
 
 uint32_t RtcGet()
 {
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("DEBUG_OUTPUT_RTC: RtcGet() for DS1302 RTC entered.");
+  Serial.println("DEBUG_OUTPUT_RTC: Calling RTC.GetDateTime()...");
+#endif
   RtcDateTime temptime;
-  temptime = Rtc.GetDateTime();
+  temptime = RTC.GetDateTime();
   uint32_t returnvalue = temptime.Unix32Time();
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.print("DEBUG_OUTPUT_RTC: RTC.GetDateTime() returned: ");
   Serial.println(returnvalue);
+#endif
   return returnvalue;
 }
 
 void RtcSet(uint32_t tt)
 {
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("DEBUG_OUTPUT_RTC: RtcSet() for DS1302 RTC entered.");
+  Serial.print("DEBUG_OUTPUT_RTC: Setting DS1302 RTC to: ");
+  Serial.println(tt);
+#endif
   RtcDateTime temptime;
   temptime.InitWithUnix32Time(tt);
-  Rtc.SetDateTime(temptime);
+#ifdef DEBUG_OUTPUT
+  Serial.println("DEBUG_OUTPUT_RTC: DS1302 RTC time set.");
+#endif
+  RTC.SetDateTime(temptime);
 }
-#else
-// For the DS1307 RTC
-#include <DS1307RTC.h>
-void RtcBegin() {}
-uint32_t RtcGet()
+#elif defined(HARDWARE_NovelLife_SE_CLOCK) // for NovelLife_SE clone with R8025T RTC chip
+#include <RTC_RX8025T.h>                   // This header will now use Wire1 for I2C operations.
+
+RX8025T RTC;
+
+void RtcBegin()
 {
-  return RTC.get();
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("");
+  Serial.println("DEBUG_OUTPUT_RTC: Trying to call RTC.Init()");
+#endif
+  RTC.init((uint32_t)RTC_SDA_PIN, (uint32_t)RTC_SCL_PIN); // setup second I2C for the RX8025T RTC chip
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("DEBUG_OUTPUT_RTC: RTC RX8025T initialized!");
+#endif
+  delay(100);
+  return;
 }
+
 void RtcSet(uint32_t tt)
 {
-  RTC.set(tt);
-}
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.print("DEBUG_OUTPUT_RTC: Setting RX8025T RTC to: ");
+  Serial.println(tt);
 #endif
+
+  int ret = RTC.set(tt);
+  if (ret != 0)
+  {
+    Serial.print("Error setting RX8025T RTC: ");
+    Serial.println(ret);
+  }
+  else
+  {
+#ifdef DEBUG_OUTPUT_RTC
+    Serial.println("DEBUG_OUTPUT_RTC: RX8025T RTC time set successfully!");
+#endif
+  }
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("DEBUG_OUTPUT_RTC: RX8025T RTC time set.");
+#endif
+}
+
+uint32_t RtcGet()
+{
+  uint32_t returnvalue = RTC.get(); // Get the RTC time
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.print("DEBUG_OUTPUT_RTC: RtcGet() RX8025T returned: ");
+  Serial.println(returnvalue);
+#endif
+  return returnvalue;
+}
+#else // for Elekstube and all other clocks with DS3231 RTC chip or DS1307/PCF8523
+#include <RTClib.h>
+
+RTC_DS3231 RTC; // DS3231, works also with DS1307 or PCF8523
+
+void RtcBegin()
+{
+  if (!RTC.begin())
+  {
+    Serial.println("NO supported RTC found!");
+  }
+  else
+  {
+#ifdef DEBUG_OUTPUT_RTC
+    Serial.println("DEBUG_OUTPUT_RTC: RTC found!");
+#endif
+  }
+
+  // check if the RTC chip reports a power failure
+  bool bPowerLost = 0;
+  bPowerLost = RTC.lostPower();
+  if (bPowerLost)
+  {
+    Serial.println("RTC reports power was lost! Setting time to default value.");
+    RTC.adjust(DateTime(2023, 1, 1, 0, 0, 0)); // set the RTC time to a default value
+  }
+}
+
+uint32_t RtcGet()
+{
+  DateTime now = RTC.now(); // convert to unix time
+  uint32_t returnvalue = now.unixtime();
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.print("DEBUG_OUTPUT_RTC: DS3231 RTC now.unixtime() = ");
+  Serial.println(returnvalue);
+#endif
+  return returnvalue;
+}
+
+void RtcSet(uint32_t tt)
+{
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.print("DEBUG_OUTPUT_RTC: Attempting to set DS3231 RTC to: ");
+  Serial.println(tt);
+#endif
+
+  DateTime timetoset(tt); // convert to unix time
+  RTC.adjust(timetoset);  // set the RTC time
+#ifdef DEBUG_OUTPUT
+  Serial.println("DEBUG_OUTPUT_RTC: DS3231 RTC time updated.");
+#endif
+}
+#endif // end of RTC chip selection
 
 void Clock::begin(StoredConfig::Config::Clock *config_)
 {
@@ -110,17 +211,17 @@ void Clock::loop()
 // Static methods used for sync provider to TimeLib library.
 time_t Clock::syncProvider()
 {
-  Serial.println("syncProvider()");
+#ifdef DEBUG_OUTPUT_RTC
+  Serial.println("Clock:syncProvider() entered.");
+#endif
   time_t rtc_now;
-  rtc_now = RtcGet();
+  rtc_now = RtcGet(); // Get the RTC time
 
-  if (millis() - millis_last_ntp > refresh_ntp_every_ms || millis_last_ntp == 0)
-  {
+  if (millis() - millis_last_ntp > refresh_ntp_every_ms || millis_last_ntp == 0) // Get NTP time only every 10 minutes or if not yet done
+  {                                                                              // It's time to get a new NTP sync
     if (WifiState == connected)
-    {
-      // It's time to get a new NTP sync
-      Serial.print("Getting NTP.");
-      //      ntpTimeClient.forceUpdate();  // maybe this breaks the NTP requests as this should not be done more than every minute.
+    { // We have WiFi, so try to get NTP time.
+      Serial.print("Try to get the actual time from NTP server...");
       if (ntpTimeClient.update())
       {
         Serial.print(".");
@@ -128,27 +229,41 @@ time_t Clock::syncProvider()
         Serial.println("NTP query done.");
         Serial.print("NTP time = ");
         Serial.println(ntpTimeClient.getFormattedTime());
-        //      if (ntp_now > 1644601505) { //is it valid - reasonable number?
+        rtc_now = RtcGet(); // Get the RTC time again, because it may have changed in the meantime
         // Sync the RTC to NTP if needed.
-        Serial.println("NTP, RTC, Diff: ");
+        Serial.print("NTP  :");
         Serial.println(ntp_now);
+        Serial.print("RTC  :");
         Serial.println(rtc_now);
+        Serial.print("Diff: ");
         Serial.println(ntp_now - rtc_now);
-        if (ntp_now != rtc_now)
-        {
+        if ((ntp_now != rtc_now) && (ntp_now > 1743364444)) // check if we have a difference and a valid NTP time
+        {                                                   // NTP time is valid and different from RTC time
+          Serial.println("RTC time is not valid, updating RTC.");
           RtcSet(ntp_now);
-          Serial.println("Updating RTC");
+          Serial.println("RTC is now set to NTP time.");
+          rtc_now = RtcGet(); // Check if RTC time is set correctly
+          Serial.print("RTC time = ");
+          Serial.println(rtc_now);
         }
-        millis_last_ntp = millis();
-        Serial.println("Using NTP time.");
+        else if ((ntp_now != rtc_now) && (ntp_now < 1743364444))
+        { // NTP can't be valid!
+          Serial.println("Time returned from NTP is not valid! Using RTC time!");
+          rtc_now = RtcGet(); // Get the RTC time again, because it may have changed in the meantime
+          return rtc_now;
+        }
+        millis_last_ntp = millis(); // store the last time we tried to get NTP time
+
+        Serial.println("Using NTP time!");
         return ntp_now;
       }
       else
-      { // NTP valid
+      {                     // NTP return value is not valid
+        rtc_now = RtcGet(); // Get the RTC time again, because it may have changed in the meantime
         Serial.println("Invalid NTP response, using RTC time.");
         return rtc_now;
       }
-    } // no wifi
+    } // no WiFi!
     Serial.println("No WiFi, using RTC time.");
     return rtc_now;
   }

--- a/EleksTubeHAX_pio/src/GLOBAL_DEFINES.h
+++ b/EleksTubeHAX_pio/src/GLOBAL_DEFINES.h
@@ -156,36 +156,35 @@
 // Pins ADPS interupt
 #define GESTURE_SENSOR_INPUT_PIN (GPIO_NUM_5) // -> INTERRUPT
 
-// I2C to DS3231 RTC.
-#define RTC_SCL_PIN (22)
-#define RTC_SDA_PIN (21)
+// Second I2C to R8025T RTC.
+#define RTC_SCL_PIN (GPIO_NUM_32)
+#define RTC_SDA_PIN (GPIO_NUM_33)
 
 // Chip Select shift register, to select the display
-#define CSSR_DATA_PIN (14)
-#define CSSR_CLOCK_PIN (13) // SHcp changed from IO16 in original Elekstube
-#define CSSR_LATCH_PIN (15) // STcp was IO17 in original Elekstube
-
-// SPI to displays
-// DEFINED IN User_Setup.h
-// Look for: TFT_MOSI, TFT_SCLK, TFT_CS, TFT_DC, and TFT_RST
+#define CSSR_DATA_PIN (GPIO_NUM_14)
+#define CSSR_CLOCK_PIN (GPIO_NUM_13) // SHcp changed from IO16 in original Elekstube
+#define CSSR_LATCH_PIN (GPIO_NUM_15) // STcp was IO17 in original Elekstube
 
 // Power for all TFT displays are grounded through a MOSFET so they can all be turned off.
 // Active HIGH.
-#define TFT_ENABLE_PIN (4) /// Was 27 on elekstube
+#define TFT_ENABLE_PIN GPIO_NUM_4 /// Was 27 on elekstube
 
 // configure library \TFT_eSPI\User_Setup.h
 // ST7789 135 x 240 display with no chip select line
 #define ST7789_DRIVER // Configure all registers
 #define TFT_WIDTH 135
 #define TFT_HEIGHT 240
-#define CGRAM_OFFSET // Library will add offsets required
-#define TFT_SDA_READ // Read and write on the MOSI/SDA pin, no separate MISO pin
-#define TFT_MOSI 23
-#define TFT_SCLK 18
-// #define TFT_CS    -1 // Not connected
-#define TFT_DC 25  // Data Command, aka Register Select or RS
-#define TFT_RST 26 // Connect reset to ensure display initialises
 
+// SPI to displays
+#define TFT_SDA_READ // Read and write on the MOSI/SDA pin, no separate MISO pin
+#define TFT_MOSI (GPIO_NUM_23)
+#define TFT_SCLK (GPIO_NUM_18)
+#define TFT_CS -1              // Not connected -> via shift register
+#define TFT_DC (GPIO_NUM_25)   // Data Command, aka Register Select or RS
+#define TFT_RST (GPIO_NUM_26)  // Connect reset to ensure display initialises
+#define SPI_FREQUENCY 40000000 // 40MHz SPI speed
+
+#define CGRAM_OFFSET // Library will add offsets required
 // #define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
 #define LOAD_FONT2 // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
 #define LOAD_FONT4 // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
@@ -194,13 +193,10 @@
 // #define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
 // #define LOAD_FONT8N // Font 8. Alternative to Font 8 above, slightly narrower, so 3 digits fit a 160 pixel TFT
 // #define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
-
 #define SMOOTH_FONT
-// #define SPI_FREQUENCY  27000000
+
 #define SPI_FREQUENCY 40000000
-/*
- * To make the Library not over-write all this:
- */
+// To make the TFT_eSPI library not over-write all this with its default settings:
 #define USER_SETUP_LOADED
 #endif // NovelLife_SE Clone XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
+++ b/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
@@ -8,9 +8,11 @@
 #ifndef USER_DEFINES_H_
 #define USER_DEFINES_H_
 
-// #define DEBUG_OUTPUT_IMAGES
-// #define DEBUG_OUTPUT_MQTT
-// #define DEBUG_OUTPUT
+// #define DEBUG_OUTPUT // uncomment for Debug printing via serial interface
+
+// #define DEBUG_OUTPUT_IMAGES // uncomment for Debug printing of image loading and drawing
+// #define DEBUG_OUTPUT_MQTT // uncomment for Debug printing of MQTT messages
+// #define DEBUG_OUTPUT_RTC // uncomment for Debug printing of RTC chip initialization and time setting
 
 // ************* Type of the clock hardware  *************
 #define HARDWARE_Elekstube_CLOCK // uncomment for the original Elekstube clock

--- a/EleksTubeHAX_pio/src/main.cpp
+++ b/EleksTubeHAX_pio/src/main.cpp
@@ -734,14 +734,14 @@ void loop()
     }
   }
 #ifdef DEBUG_OUTPUT
-  if (time_in_loop <= 1)
+  if (time_in_loop <= 2) // if the loop time is less than 2ms, we don't need to print it in detail
     Serial.print(".");
   else
   {
-    Serial.print("time spent in loop (ms): ");
+    Serial.print("time spent in loop (ms): "); // print the time spent in the loop
     Serial.println(time_in_loop);
   }
-#endif
+#endif // DEBUG_OUTPUT
 }
 
 #ifdef HARDWARE_NovelLife_SE_CLOCK // NovelLife_SE Clone XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/EleksTubeHAX_pio/src/main.cpp
+++ b/EleksTubeHAX_pio/src/main.cpp
@@ -131,10 +131,10 @@ void setup()
   // Setup the clock.  It needs WiFi to be established already.
   tfts.setTextColor(TFT_MAGENTA, TFT_BLACK);
   tfts.print("Clock start...");
-  Serial.print("Clock start...");
+  Serial.println("Clock start-up...");
   uclock.begin(&stored_config.config.uclock);
   tfts.println("Done!");
-  Serial.println("Done!");
+  Serial.println("Clock start-up done!");
   tfts.setTextColor(TFT_WHITE, TFT_BLACK);
 
 #if defined(MQTT_PLAIN_ENABLED) || defined(MQTT_HOME_ASSISTANT)


### PR DESCRIPTION
I've implemented several improvements and fixes for the Real-Time Clock (RTC) handling.

- RTC R8025T support for the NovelLifeSE clock: This includes a modified library to accommodate the second I2C bus required by this clock.
- Using RTCLib for DS3231 and DS1307 clocks (EleksTube 1st and 2nd Gen).
- Removed the DS1307 library from Paul Stoffregen: This change aligns with the use of RTCLib for all supported DS series clocks.
- Added additional debug messages for RTC handling: These messages should provide more detailed information during troubleshooting.
- Added "RTC power loss reset" for DS3231: This feature aims to handle scenarios where the DS3231 loses power.
- For DS1307 power reading is not working, but lostPower() reports always false, so no problem.
- Changed the order of the RTC set and get in combination with the NTP.
- Removed some unused code
- Slightly modified the GLOBAL_DEFINES.h for NovelLifeSE.

Off-topic: Increased the delay for the dot printing in the loop() function when debug output is active (now 2ms instead of 1ms).