### PR TITLE
Add supported_color_mode for discovery messages and color_mode to MQTT state messages

### DIFF
--- a/EleksTubeHAX_pio/src/MQTT_client_ips.cpp
+++ b/EleksTubeHAX_pio/src/MQTT_client_ips.cpp
@@ -297,6 +297,7 @@ void MQTTReportState(bool forceUpdateEverything)
     state["state"] = MQTTStatusMainPower == 0 ? MQTT_STATE_OFF : MQTT_STATE_ON;
     state["brightness"] = MQTTStatusMainBrightness;
     state["effect"] = tfts.clockFaceToName(MQTTStatusMainGraphic);
+    state["color_mode"] = "brightness";
 
     if (!MQTTPublish(concat3(MQTT_CLIENT, "/", TopicFront), &state, MQTT_RETAIN_STATE_MESSAGES))
       return;
@@ -973,6 +974,7 @@ bool MQTTReportDiscovery()
   discovery["state_topic"] = concat3(MQTT_CLIENT, "/", TopicFront);
   discovery["json_attributes_topic"] = concat3(MQTT_CLIENT, "/", TopicFront);
   discovery["command_topic"] = concat4(MQTT_CLIENT, "/", TopicFront, "/set");
+  discovery["supported_color_modes"][0] = "brightness";
   discovery["brightness"] = true;
   discovery["brightness_scale"] = MQTT_BRIGHTNESS_MAIN_MAX;
   discovery["effect"] = true;


### PR DESCRIPTION
Fix: Resolve Home Assistant `color_mode` warnings and errors via MQTT

This pull request addresses the logged Home Assistant warning and error indicating that `color_mode` was not being reported via MQTT in the status messages of the main light and that `color_mode` was not supported.

The following changes have been implemented:

- Added the `"supported_color_mode"` field with the value `"brightness"` to the discovery message of the main light. This explicitly informs Home Assistant about the supported color mode.
- Ensured the removal of the `"color_mode"` field from the discovery message, as this was already handled in the previous PR and was the source of the error.
- Added the `"color_mode"` field with the value `"brightness"` to the `"normal"` status message of the main light. This ensures the current color mode is correctly reported, resolving the warning.

These adjustments ensure proper communication of the light's color mode capabilities to Home Assistant over MQTT, eliminating the reported issues.